### PR TITLE
Add flag to skip audit over corelist

### DIFF
--- a/lib/CPAN/Audit.pm
+++ b/lib/CPAN/Audit.pm
@@ -23,6 +23,7 @@ sub new {
     $self->{verbose}     = $params{verbose};
     $self->{quiet}       = $params{quiet};
     $self->{no_color}    = $params{no_color};
+    $self->{no_corelist} = $params{no_corelist};
     $self->{interactive} = $params{interactive};
 
     if ( !$self->{interactive} ) {
@@ -43,9 +44,14 @@ sub command {
 
     my %dists;
 
-    # Find core modules for this perl version first.
-    # This way explictly installed versions will overwrite.
-    if ( $command eq 'dependencies' || $command eq 'deps' || $command eq 'installed' ) {
+    if (!$self->{no_corelist}
+        && (   $command eq 'dependencies'
+            || $command eq 'deps'
+            || $command eq 'installed' )
+        )
+    {
+        # Find core modules for this perl version first.
+        # This way explictly installed versions will overwrite.
         if ( my $core = $Module::CoreList::version{$]} ) {
             while ( my ( $mod, $ver ) = each %$core ) {
                 my $dist = $self->{db}{module2dist}{$mod} or next;

--- a/script/cpan-audit
+++ b/script/cpan-audit
@@ -7,16 +7,18 @@ use Getopt::Long;
 use CPAN::Audit;
 
 my $opt_no_color;
+my $opt_no_corelist;
 my $opt_ascii;
 my $opt_verbose;
 my $opt_quiet;
 my $opt_help;
 GetOptions(
-    'no-color'  => \$opt_no_color,
-    'ascii'     => \$opt_ascii,
-    'verbose|v' => \$opt_verbose,
-    'quiet|q'   => \$opt_quiet,
-    'help|h'    => \$opt_help,
+    'no-color'    => \$opt_no_color,
+    'no-corelist' => \$opt_no_corelist,
+    'ascii'       => \$opt_ascii,
+    'verbose|v'   => \$opt_verbose,
+    'quiet|q'     => \$opt_quiet,
+    'help|h'      => \$opt_help,
 ) or die("Error in command line arguments\n");
 
 pod2usage( -input => $FindBin::Bin . "/" . $FindBin::Script ) if $opt_help;
@@ -29,6 +31,7 @@ if ( !$command ) {
 
 my $audit = CPAN::Audit->new(
     no_color    => $opt_no_color,
+    no_corelist => $opt_no_corelist,
     ascii       => $opt_ascii,
     verbose     => $opt_verbose,
     quiet       => $opt_quiet,
@@ -57,11 +60,12 @@ Commands:
 
 Options:
 
-    --no-color     switch off colors
-    --ascii        use ascii output
-    --quiet        be quiet
-    --verbose      be verbose
-    --help|h       help message
+    --no-color    switch off colors
+    --no-corelist ignore modules bundled with perl version
+    --ascii       use ascii output
+    --quiet       be quiet
+    --verbose     be verbose
+    --help|h      help message
 
 Examples:
 


### PR DESCRIPTION
I've added an opt-in flag to skip the auditing of modules installed under the currently running Perl version.

This would be useful in my case, where I'm not as concerned with vulnerabilities associated with my running version of Perl, and I don't want cpan-audit to report these as failures.