### PR TITLE
Fix a wrong distribution name

### DIFF
--- a/lib/CPAN/Audit/DB.pm
+++ b/lib/CPAN/Audit/DB.pm
@@ -22812,7 +22812,7 @@ sub db {
                                                            }
                                                          ]
                                          },
-                       'Plack-Middleware-Session-Cookie' => {
+                       'Plack-Middleware-Session' => {
                                                               'advisories' => [
                                                                                 {
                                                                                   'affected_versions' => '<=0.21',


### PR DESCRIPTION
Plack::Middleware::Session::Cookie resides in Plack-Middleware-Session distribution